### PR TITLE
Remove stack setup from github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
     
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
-    
     - name: Cache Stack downloads
       uses: actions/cache@v1
       env:
@@ -80,9 +77,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
     
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
-    
     - name: Cache Stack downloads
       uses: actions/cache@v1
       env:
@@ -134,9 +128,6 @@ jobs:
 
     - name: Get code
       uses: actions/checkout@v2
-    
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
     
     - name: Cache Stack downloads
       uses: actions/cache@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,6 @@ jobs:
         repository: zellige/zellige
         path: ./zellige
     
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
-    
     - name: Cache Stack downloads
       uses: actions/cache@v1
       env:
@@ -91,9 +88,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
     
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
-    
     - name: Cache Stack downloads
       uses: actions/cache@v1
       env:
@@ -145,9 +139,6 @@ jobs:
 
     - name: Get code
       uses: actions/checkout@v2
-    
-    - name: Setup Stack
-      uses: mstksg/setup-stack@v2
     
     - name: Cache Stack downloads
       uses: actions/cache@v1


### PR DESCRIPTION
As per https://github.com/mstksg/setup-stack/issues/7 the OSX builds are no longer working.

This is apparently no longer needed as github includes stack by default.